### PR TITLE
#26441 #26715 update translation through multilinual plugin, called DeepL API trough proxy enpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+
+## [0.2.0]
+### Changed
+* plugin will emit `flotiq-multilingual.translation::update` event to update translation through multilinual plugin #26441
+* DeepL API is now called through dedicated proxy #26715
+
+### Fixed
+* plugin will no longer tranlsate default language values

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -2,7 +2,7 @@
   "id": "flotiq.translation-deepl",
   "name": "DeepL Translation plugin",
   "description": "Use DeepL to translate your content. This plugin requires the Flotiq Multilingual plugin.",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "repository": "https://github.com/flotiq/flotiq-ui-plugin-deepl",
   "url": "https://localhost:3053/index.js",
   "permissions": []

--- a/plugins/form-config/co-form/index.js
+++ b/plugins/form-config/co-form/index.js
@@ -12,7 +12,7 @@ import { createTranslateButton } from './button';
  * @param toast
  */
 export const handleCoFormConfig = (
-  { contentType, name, config, formik },
+  { contentType, name, config, formik, initialData, formUniqueKey },
   contentTypeSettings,
   toast,
 ) => {
@@ -32,6 +32,8 @@ export const handleCoFormConfig = (
         settings: contentTypeSettings,
         formik,
         contentType,
+        initialData,
+        formUniqueKey,
       };
 
       button = createTranslateButton(buttonData, toast);


### PR DESCRIPTION
This PR is adding new event `flotiq-multilingual.translation::update` which is emitted when translations should be updated. From now plugin will update translation through multilinual plugin (https://github.com/flotiq/flotiq-ui-plugin-multilingual/pull/9)

DeepL API is now called through dedicated proxy.